### PR TITLE
Added details for <model> poster attribute

### DIFF
--- a/model/README.md
+++ b/model/README.md
@@ -181,6 +181,7 @@ property to `false` removes the `interactive` HTML attribute if present, while s
 adds the `interactive` HTML attribute if absent.
 * `loading`: behaves in the same manner as the
 [`img` attribute of the same name](https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-loading).
+* `poster`: behaves in the same manner as the [`video` attribute of the same name](https://html.spec.whatwg.org/multipage/media.html#attr-video-poster)
 
 Similar to other elements with sub-resources, the `HTMLModelElement` will provide
 APIs to observe the loading and decoding of data.


### PR DESCRIPTION
closes #79 

The `poster` attribute is mentioned elsewhere in the document but is not in the attribute list. This PR simply adds the poster attribute to the list of supported attributes.
