### PR TITLE
{Video|Audio}TrackConfiguration should be a dictionary

### DIFF
--- a/TrackConfiguration/README.md
+++ b/TrackConfiguration/README.md
@@ -34,19 +34,19 @@ The `HTMLMediaElement`’s `VideoTrack` and `AudioTrack` objects would vend a ne
 
 ```
 dictionary VideoTrackConfiguration {
-    attribute DOMString codec;
-    attribute unsigned long long bitrate;
-    attribute double framerate;
-    attribute unsigned long width;
-    attribute unsigned long height;
-    attribute VideoColorSpace colorSpace;
+    DOMString codec;
+    unsigned long long bitrate;
+    double framerate;
+    unsigned long width;
+    unsigned long height;
+    VideoColorSpace colorSpace;
 };
 
 dictionary AudioTrackConfiguration {
-    attribute DOMString codec;
-    attribute unsigned long long bitrate;
-    attribute unsigned long sampleRate;
-    attribute unsigned long numberOfChannels;
+    DOMString codec;
+    unsigned long long bitrate;
+    unsigned long sampleRate;
+    unsigned long numberOfChannels;
 };
 
 partial interface VideoTrack {

--- a/TrackConfiguration/README.md
+++ b/TrackConfiguration/README.md
@@ -33,20 +33,20 @@ A page would like to validate that its encoder and muxer generates media whose `
 The `HTMLMediaElement`’s `VideoTrack` and `AudioTrack` objects would vend a new attribute `VideoTrackConfiguration` and `AudioTrackConfiguration`. 
 
 ```
-interface VideoTrackConfiguration {
-    readonly attribute DOMString codec;
-    readonly attribute unsigned long long bitrate;
-    readonly attribute double framerate;
-    readonly attribute unsigned long width;
-    readonly attribute unsigned long height;
-    readonly attribute VideoColorSpace colorSpace;
+dictionary VideoTrackConfiguration {
+    attribute DOMString codec;
+    attribute unsigned long long bitrate;
+    attribute double framerate;
+    attribute unsigned long width;
+    attribute unsigned long height;
+    attribute VideoColorSpace colorSpace;
 };
 
-interface AudioTrackConfiguration {
-    readonly attribute DOMString codec;
-    readonly attribute unsigned long long bitrate;
-    readonly attribute unsigned long sampleRate;
-    readonly attribute unsigned long numberOfChannels;
+dictionary AudioTrackConfiguration {
+    attribute DOMString codec;
+    attribute unsigned long long bitrate;
+    attribute unsigned long sampleRate;
+    attribute unsigned long numberOfChannels;
 };
 
 partial interface VideoTrack {


### PR DESCRIPTION
 Partially address Issue #98 by making the configuration objects `dictionary` types rather than `interfaces.