### PR TITLE
Fix link to Explainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WebKit Explainers
 
-This repo is a place where WebKit contributors may post [explainers](https://github.com/w3ctag/w3ctag.github.io/blob/master/explainers.md) of pre-standardization web platform feature ideas, and a place where these explainers can be discussed, refined, and readied for migration to appropriate standards bodies (such as the [Privacy CG](https://github.com/privacycg/) or [WICG](https://github.com/WICG)).
+This repo is a place where WebKit contributors may post [explainers](https://www.w3.org/TR/explainer-explainer/) of pre-standardization web platform feature ideas, and a place where these explainers can be discussed, refined, and readied for migration to appropriate standards bodies (such as the [Privacy CG](https://github.com/privacycg/) or [WICG](https://github.com/WICG)).
 
 ## Explainers
 


### PR DESCRIPTION
Current link is 404 